### PR TITLE
Fix bookmark xpath to find bookmark in any document part.

### DIFF
--- a/R/docx_document.R
+++ b/R/docx_document.R
@@ -73,7 +73,7 @@ docx_document <- R6Class(
 
       bm_id <- xml_attr(bm_start, "id")
 
-      xpath_ <- sprintf("/w:document/w:body/*[w:bookmarkStart[@w:id='%s']]", bm_id)
+      xpath_ <- sprintf("/w:document/w:body//*[w:bookmarkStart[@w:id='%s']]", bm_id)
       par_with_bm <- xml_find_first(self$get(), xpath_)
 
       cursor <- xml_path(par_with_bm)


### PR DESCRIPTION
This fix was needed for officer to move the cursor for me into a paragraph in a text box.