### PR TITLE
Fix for corrupt content warnings in older PowerPoint versions

### DIFF
--- a/R/ppt_classes.R
+++ b/R/ppt_classes.R
@@ -105,8 +105,8 @@ presentation <- R6Class(
 
       if( !inherits(xml_list, "xml_missing")){
         xml_replace(xml_list, xml_elt)
-      } else{ ## needs to be after sldMasterIdLst...
-        xml_add_sibling(xml_find_first(private$doc, "//p:sldMasterIdLst"), xml_elt)
+      } else{ ## needs to be after all MasterIdLst elements. placing it before sldSz seems to be the safest option.
+        xml_add_sibling(xml_find_first(private$doc, "//p:sldSz"), xml_elt, .where = "before")
       }
 
       self


### PR DESCRIPTION
@davidgohel this will fix the error message you mention here: https://github.com/davidgohel/officer/issues/151#issuecomment-423848799. I assume you're keeping the issue open because of this, if so this commit will resolve #151.

After some debugging I found that it was the placement of the `p:sldIdLst`, created by `add_slide` if there are no slides in the presentation, that was causing the issue. See this diff between a faulty file (a) and a working file (b):
<img width="385" alt="screen shot 2018-10-25 at 21 48 17" src="https://user-images.githubusercontent.com/34108452/47527324-958ac000-d8a2-11e8-8cb7-909136044196.png">
