### PR TITLE
Make inserted image correct size

### DIFF
--- a/R/docx_part.R
+++ b/R/docx_part.R
@@ -133,7 +133,7 @@ docx_part <- R6Class(
       dir.create(img_path, recursive = TRUE, showWarnings = FALSE)
       file.copy(from = new_src, to = file.path(private$package_dir, "word", "media", basename(new_src)))
 
-      out <- wml_image(paste0("rId", blip_id), width = width*72, height = height*72)
+      out <- wml_image(paste0("rId", blip_id), width = width, height = height)
 
       xml_replace(run_nodes[[1]], as_xml_document(out) )
       self


### PR DESCRIPTION
This fixes a problem when inserting images.  When using `body_replace_img_at_bkm()`, images were oversized, which I traced to the `wml_image()` call in `cursor_replace_first_img()`.  Removing the multiplication by 72 fixed the immediate problem, though I haven't tested this thoroughly to see if it creates other issues.


This reprex shows the current problem.  (Output attached: [out.docx](https://github.com/davidgohel/officer/files/3004174/out.docx))  I am opening the file on Word for Mac 16.16.8.

```
library(magrittr)
library(officer)=
img.file <- file.path( R.home("doc"), "html", "logo.jpg" )
doc <- read_docx() %>%
  body_add_par("centered text", style = "centered") %>%
  slip_in_text(". How are you", style = "strong") %>%
  body_bookmark("text_to_replace") %>%
  body_replace_img_at_bkm("text_to_replace", value = external_img(src = img.file, width = .53, height = .7))
print(doc, "out.docx")
```

Session info:


<details>

```

> sessioninfo::session_info()
─ Session info ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 setting  value                       
 version  R version 3.5.1 (2018-07-02)
 os       macOS  10.14.3              
 system   x86_64, darwin15.6.0        
 ui       RStudio                     
 language (EN)                        
 collate  en_US.UTF-8                 
 ctype    en_US.UTF-8                 
 tz       America/New_York            
 date     2019-03-25                  

─ Packages ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 package     * version   date       lib source                                     
 assertthat    0.2.0     2017-04-11 [1] CRAN (R 3.5.0)                             
 base64enc     0.1-3     2015-07-28 [1] CRAN (R 3.5.0)                             
 cli           1.0.1     2018-09-25 [1] CRAN (R 3.5.1)                             
 colorspace    1.4-1     2019-02-27 [1] Github (rforge/colorspace@c795f29)         
 crayon        1.3.4     2017-09-16 [1] CRAN (R 3.5.0)                             
 digest        0.6.18    2018-10-10 [1] CRAN (R 3.5.0)                             
 dplyr         0.8.0.1   2019-02-15 [1] CRAN (R 3.5.2)                             
 ehastyle      0.1.0     2019-03-25 [1] Github (ecohealthalliance/ehastyle@0088f62)
 evaluate      0.13      2019-02-12 [1] CRAN (R 3.5.2)                             
 ggplot2       3.1.0     2018-10-25 [1] CRAN (R 3.5.0)                             
 glue          1.3.1     2019-03-12 [1] CRAN (R 3.5.1)                             
 gtable        0.2.0     2016-02-26 [1] CRAN (R 3.5.0)                             
 htmltools     0.3.6     2017-04-28 [1] CRAN (R 3.5.0)                             
 knitr         1.22      2019-03-08 [1] CRAN (R 3.5.2)                             
 lazyeval      0.2.1     2017-10-29 [1] CRAN (R 3.5.0)                             
 linl          0.0.3     2018-12-15 [1] CRAN (R 3.5.0)                             
 magrittr    * 1.5       2014-11-22 [1] CRAN (R 3.5.0)                             
 munsell       0.5.0     2018-06-12 [1] CRAN (R 3.5.0)                             
 officer     * 0.3.4.003 2019-03-25 [1] local                                      
 packrat       0.5.0     2018-11-14 [1] CRAN (R 3.5.0)                             
 pillar        1.3.1     2018-12-15 [1] CRAN (R 3.5.0)                             
 pkgconfig     2.0.2     2018-08-16 [1] CRAN (R 3.5.0)                             
 plyr          1.8.4     2016-06-08 [1] CRAN (R 3.5.0)                             
 purrr         0.3.2     2019-03-15 [1] CRAN (R 3.5.1)                             
 R6            2.4.0     2019-02-14 [1] CRAN (R 3.5.1)                             
 Rcpp          1.0.1     2019-03-17 [1] CRAN (R 3.5.1)                             
 rlang         0.3.2     2019-03-21 [1] CRAN (R 3.5.1)                             
 rmarkdown     1.12.3    2019-03-25 [1] Github (rstudio/rmarkdown@503cc5f)         
 rstudioapi    0.9.0     2019-01-09 [1] CRAN (R 3.5.2)                             
 scales        1.0.0     2018-08-09 [1] CRAN (R 3.5.0)                             
 sessioninfo   1.1.1     2018-11-05 [1] CRAN (R 3.5.0)                             
 tibble        2.0.1     2019-01-12 [1] CRAN (R 3.5.2)                             
 tidyselect    0.2.5     2018-10-11 [1] CRAN (R 3.5.0)                             
 uuid          0.1-2     2015-07-28 [1] CRAN (R 3.5.0)                             
 withr         2.1.2     2018-03-15 [1] CRAN (R 3.5.0)                             
 xfun          0.5       2019-02-20 [1] CRAN (R 3.5.2)                             
 xml2          1.2.0     2018-01-24 [1] CRAN (R 3.5.0)                             
 yaml          2.2.0     2018-07-25 [1] CRAN (R 3.5.0)                             
 zip           2.0.1     2019-03-11 [1] CRAN (R 3.5.2)                             

[1] /Library/Frameworks/R.framework/Versions/3.5/Resources/library
```

</details>