### PR TITLE
Fix for #82

### DIFF
--- a/R/fortify_pptx.R
+++ b/R/fortify_pptx.R
@@ -105,6 +105,7 @@ media_extract <- function( x, path, target ){
 #'   "doc_examples/example.pptx")
 #' doc <- read_pptx(example_pptx)
 #' pptx_summary(doc)
+#' pptx_summary(example_pptx)
 #' @export
 pptx_summary <- function( x ){
   if (is.character(x)) {

--- a/R/fortify_pptx.R
+++ b/R/fortify_pptx.R
@@ -107,7 +107,9 @@ media_extract <- function( x, path, target ){
 #' pptx_summary(doc)
 #' @export
 pptx_summary <- function( x ){
-
+  if (is.character(x)) {
+    x = read_pptx(x)
+  }
   list_content <- list()
   for( i in seq_len( length(x) )){
     slide <- x$slide$get_slide(i)

--- a/R/read_pptx.R
+++ b/R/read_pptx.R
@@ -42,6 +42,10 @@ read_pptx <- function( path = NULL ){
 
 read_table_style <- function(path){
   file <- file.path(path, "ppt/tableStyles.xml")
+  if (!file.exists(file)) {
+    warning("tableStyles.xml file does not exist in PPTX")
+    return(NULL)
+  }
   doc <- read_xml(file)
   nodes <- xml_find_all(doc, "//a:tblStyleLst")
   data.frame(def = xml_attr(nodes, "def"),

--- a/man/pptx_summary.Rd
+++ b/man/pptx_summary.Rd
@@ -18,4 +18,5 @@ example_pptx <- system.file(package = "officer",
   "doc_examples/example.pptx")
 doc <- read_pptx(example_pptx)
 pptx_summary(doc)
+pptx_summary(example_pptx)
 }

--- a/tests/testthat/test-missing-tableStyles.R
+++ b/tests/testthat/test-missing-tableStyles.R
@@ -1,0 +1,15 @@
+context("Missing tableStyles ")
+
+destfile = tempfile(fileext = ".pptx")
+download.file("https://ndownloader.figshare.com/files/16252631",
+              destfile = destfile)
+
+test_that("missing tableStyles file in pptx from figshare", {
+  expect_warning({
+    x <- read_pptx(destfile)
+  })
+
+})
+
+file.remove(destfile)
+


### PR DESCRIPTION
Fixes #82 and #219 by putting warning for the tableStyles.xml not existing and returns a `NULL`.  Also, `pptx_summary` can just take in a file path and it will inherently use `read_pptx` to get the `rpptx` object. 

