### PR TITLE
Fix for error in annotate_base with unknown ph types

### DIFF
--- a/R/ph_location.R
+++ b/R/ph_location.R
@@ -196,10 +196,11 @@ fortify_location.location_template <- function( x, doc, ...){
 #' @example examples/ph_location_type.R
 ph_location_type <- function( type = "body", position_right = TRUE, position_top = TRUE, newlabel = NULL, id = NULL, ...){
 
-  ph_types <- c("ctrTitle", "subTitle", "dt", "ftr",
-                "sldNum", "title", "body")
+  ph_types <- c("ctrTitle", "subTitle", "dt", "ftr", "sldNum", "title", "body",
+                "pic", "chart", "tbl", "dgm", "media", "clipArt")
   if(!type %in% ph_types){
-    warning("argument type (", type ,") unknown. Expected ", paste0(shQuote(ph_types), collapse = ", "), ".")
+    stop("argument type ('", type, "') expected to be a value of ",
+         paste0(shQuote(ph_types), collapse = ", "), ".")
   }
   x <- list(type = type, position_right = position_right, position_top = position_top, id = id, label = newlabel)
   class(x) <- c("location_type", "location_str")

--- a/R/ph_location.R
+++ b/R/ph_location.R
@@ -199,7 +199,7 @@ ph_location_type <- function( type = "body", position_right = TRUE, position_top
   ph_types <- c("ctrTitle", "subTitle", "dt", "ftr",
                 "sldNum", "title", "body")
   if(!type %in% ph_types){
-    stop("argument type must be a value of ", paste0(shQuote(ph_types), collapse = ", ", "."))
+    warning("argument type expected to be a value of ", paste0(shQuote(ph_types), collapse = ", ", "."))
   }
   x <- list(type = type, position_right = position_right, position_top = position_top, id = id, label = newlabel)
   class(x) <- c("location_type", "location_str")

--- a/R/ph_location.R
+++ b/R/ph_location.R
@@ -199,7 +199,7 @@ ph_location_type <- function( type = "body", position_right = TRUE, position_top
   ph_types <- c("ctrTitle", "subTitle", "dt", "ftr",
                 "sldNum", "title", "body")
   if(!type %in% ph_types){
-    warning("argument type expected to be a value of ", paste0(shQuote(ph_types), collapse = ", "), ".")
+    warning("argument type (", type ,") unknown. Expected ", paste0(shQuote(ph_types), collapse = ", "), ".")
   }
   x <- list(type = type, position_right = position_right, position_top = position_top, id = id, label = newlabel)
   class(x) <- c("location_type", "location_str")

--- a/R/ph_location.R
+++ b/R/ph_location.R
@@ -199,7 +199,7 @@ ph_location_type <- function( type = "body", position_right = TRUE, position_top
   ph_types <- c("ctrTitle", "subTitle", "dt", "ftr",
                 "sldNum", "title", "body")
   if(!type %in% ph_types){
-    warning("argument type expected to be a value of ", paste0(shQuote(ph_types), collapse = ", ", "."))
+    warning("argument type expected to be a value of ", paste0(shQuote(ph_types), collapse = ", "), ".")
   }
   x <- list(type = type, position_right = position_right, position_top = position_top, id = id, label = newlabel)
   class(x) <- c("location_type", "location_str")


### PR DESCRIPTION
I saved a presentation in powerpoint after adding new layout which included placeholders of various types (View > Slide Master, Slide Master > Insert placeholder dropdown):
![image](https://user-images.githubusercontent.com/4238963/78402838-25f92400-75b0-11ea-9e84-551a61adf362.png)

When I tried to use the annotate_base function with this presentation 
[all_ph_types.pptx](https://github.com/davidgohel/officer/files/4429810/all_ph_types.pptx), it failed with the error:
```
In ph_location_type(type = lp$type[pidx], id = id[pidx]) :
  argument type expected to be a value of 'ctrTitle', 'subTitle', 'dt', 'ftr', 'sldNum', 'title', 'body'.
```

I modified the function to throw a warning rather than stopping on this error. I'm not familiar enough with the package to know if/why this check is necessary.
