### PR TITLE
docx_bookmarks() detects bookmarks in header and footer too

### DIFF
--- a/R/read_docx.R
+++ b/R/read_docx.R
@@ -304,7 +304,7 @@ docx_dim <- function(x){
 #'
 #' docx_bookmarks(read_docx())
 #' @family functions for Word document informations
-docx_bookmarks = function (x) {
+docx_bookmarks <- function (x) {
   stopifnot(inherits(x, "rdocx"))
   
   doc_ <- xml_find_all(x$doc_obj$get(), "//w:bookmarkStart[@w:name]")

--- a/R/read_docx.R
+++ b/R/read_docx.R
@@ -304,11 +304,20 @@ docx_dim <- function(x){
 #'
 #' docx_bookmarks(read_docx())
 #' @family functions for Word document informations
-docx_bookmarks <- function(x){
+docx_bookmarks = function (x) {
   stopifnot(inherits(x, "rdocx"))
-
+  
   doc_ <- xml_find_all(x$doc_obj$get(), "//w:bookmarkStart[@w:name]")
-  setdiff(xml_attr(doc_, "name"), "_GoBack")
+  doc_ <- setdiff(xml_attr(doc_, "name"), "_GoBack")
+  head_ <- sapply(x$headers, function(h) {
+    tmp <- xml_find_all(h$get(), "//w:bookmarkStart[@w:name]")
+    setdiff(xml_attr(tmp, "name"), "_GoBack")
+  })
+  foot_ <- sapply(x$footers, function(f) {
+    tmp <- xml_find_all(f$get(), "//w:bookmarkStart[@w:name]")
+    setdiff(xml_attr(tmp, "name"), "_GoBack")
+  })
+  list(header=unname(unlist(head_)), body=unname(unlist(doc_)), footer=unname(unlist(foot_)))
 }
 
 #' @export

--- a/R/read_docx.R
+++ b/R/read_docx.R
@@ -304,9 +304,9 @@ docx_dim <- function(x){
 #'
 #' docx_bookmarks(read_docx())
 #' @family functions for Word document informations
-docx_bookmarks <- function (x) {
+docx_bookmarks <- function(x){
   stopifnot(inherits(x, "rdocx"))
-  
+
   doc_ <- xml_find_all(x$doc_obj$get(), "//w:bookmarkStart[@w:name]")
   doc_ <- setdiff(xml_attr(doc_, "name"), "_GoBack")
   head_ <- sapply(x$headers, function(h) {

--- a/R/read_docx.R
+++ b/R/read_docx.R
@@ -292,6 +292,8 @@ docx_dim <- function(x){
 #' @description List bookmarks id that can be found in an \code{rdocx}
 #' object.
 #' @param x an \code{rdocx} object
+#' @return a list of 3 character vectors containing the bookmarks of 
+#' respectivly the header, body and footer of the \code{rdocx} object.
 #' @examples
 #' library(magrittr)
 #'


### PR DESCRIPTION
For now, `docx_bookmarks()` only detects bookmarks in the body of the document.

This PR allows it to also detect them in the header and in the footer.

There is a breaking change as this returns a list instead of a character vector, but I thought it was not too bad as this seems to be more of a debugging function.
Alternatively, it could simply return `unname(unlist(c(doc_, head_, foot_)))`.