### PR TITLE
enable unit choice in body_add_img() and body_add_gg()

### DIFF
--- a/R/docx_add.R
+++ b/R/docx_add.R
@@ -20,8 +20,9 @@ body_add_break <- function( x, pos = "after"){
 #' @inheritParams body_add_break
 #' @param src image filename, the basename of the file must not contain any blank.
 #' @param style paragraph style
-#' @param width height in inches
-#' @param height height in inches
+#' @param width height in units
+#' @param height height in units
+#' @param units one of c("in", "cm", "mm")
 #' @examples
 #' doc <- read_docx()
 #'
@@ -119,8 +120,9 @@ body_add_docx <- function( x, src, pos = "after" ){
 #' @inheritParams body_add_break
 #' @param value ggplot object
 #' @param style paragraph style
-#' @param width height in inches
-#' @param height height in inches
+#' @param width height in units
+#' @param height height in units
+#' @param units one of c("in", "cm", "mm")
 #' @param res resolution of the png image in ppi
 #' @param ... Arguments to be passed to png function.
 #' @importFrom grDevices png dev.off

--- a/R/docx_add.R
+++ b/R/docx_add.R
@@ -32,7 +32,7 @@ body_add_break <- function( x, pos = "after"){
 #'
 #' print(doc, target = tempfile(fileext = ".docx"))
 #' @family functions for adding content
-body_add_img <- function( x, src, style = NULL, width, height, pos = "after" ){
+body_add_img <- function( x, src, style = NULL, width, height, units = c("in", "cm", "mm"), pos = "after" ){
 
   if( is.null(style) )
     style <- x$default_styles$paragraph
@@ -55,7 +55,8 @@ body_add_img <- function( x, src, style = NULL, width, height, pos = "after" ){
 
   style_id <- get_style_id(data = x$styles, style=style, type = "paragraph")
 
-  ext_img <- external_img(new_src, width = width, height = height)
+  to_inches <- function(x) x/c(`in` = 1, cm = 2.54, mm = 2.54 * 10)[units]  
+  ext_img <- external_img(new_src, width = to_inches(width), height = to_inches(height))
   xml_elt <- runs_to_p_wml(ext_img, add_ns = TRUE, style_id = style_id)
   x <- docx_reference_img(x, new_src)
   xml_elt <- wml_link_images( x, xml_elt )
@@ -136,19 +137,16 @@ body_add_docx <- function( x, src, pos = "after" ){
 #'   print(doc, target = tempfile(fileext = ".docx") )
 #' }
 #' @family functions for adding content
-body_add_gg <- function( x, value, width = 6, height = 5, res = 300, style = "Normal", ... ){
+body_add_gg <- function( x, value, width = 6, height = 5, units = c("in", "cm", "mm"), res = 300, style = "Normal", ... ){
 
   if( !requireNamespace("ggplot2") )
     stop("package ggplot2 is required to use this function")
 
   stopifnot(inherits(value, "gg") )
   file <- tempfile(fileext = ".png")
-  options(bitmapType='cairo')
-  png(filename = file, width = width, height = height, units = "in", res = res, ...)
-  print(value)
-  dev.off()
+  ggplot2::ggsave(file, value, width = width, height = height, units = units, dpi=res, ...)
   on.exit(unlink(file))
-  body_add_img(x, src = file, style = style, width = width, height = height)
+  body_add_img(x, src = file, style = style, width = width, height = height, units=units)
 }
 
 


### PR DESCRIPTION
Hi David,

Yet another PR as I use your great package extensively.

This one comes quite handy in MS Word where distances are expressed in cm and not in inches, as in the French version.

I tested on a few documents, it works at least on my computer.

I also switched to `ggplot2::ggsave` which allows one to pass on the `scale` argument. This has proven incredibly useful when trying to resize a plot properly in an `officer` document.