### PR TITLE
Add ability to add alt_text for images

### DIFF
--- a/R/ooxml_run_objects.R
+++ b/R/ooxml_run_objects.R
@@ -620,12 +620,15 @@ as.data.frame.external_img <- function( x, ... ){
 
 
 pic_pml <- function( left = 0, top = 0, width = 3, height = 3,
-                     bg = "transparent", rot = 0, label = "", ph = "<p:ph/>", src){
+                     bg = "transparent", rot = 0, label = "", ph = "<p:ph/>", src, alt_text = ""){
 
   if( !is.null(bg) && !is.color( bg ) )
     stop("bg must be a valid color.", call. = FALSE )
 
   bg_str <- solid_fill_pml(bg)
+
+  if (missing(alt_text)) alt_text <- ""
+
 
   xfrm_str <- a_xfrm_str(left = left, top = top, width = width, height = height, rot = rot)
   if( is.null(ph) || is.na(ph)){
@@ -639,7 +642,7 @@ pic_pml <- function( left = 0, top = 0, width = 3, height = 3,
   str <- "
 <p:pic xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" xmlns:p=\"http://schemas.openxmlformats.org/presentationml/2006/main\">
   <p:nvPicPr>
-    <p:cNvPr id=\"0\" name=\"%s\"/>
+    <p:cNvPr id=\"0\" name=\"%s\" descr=\"%s\"/>
     <p:cNvPicPr><a:picLocks noGrp=\"1\"/></p:cNvPicPr>
     <p:nvPr>%s</p:nvPr>
   </p:nvPicPr>
@@ -647,7 +650,7 @@ pic_pml <- function( left = 0, top = 0, width = 3, height = 3,
   <p:spPr>%s<a:prstGeom prst=\"rect\"><a:avLst/></a:prstGeom>%s</p:spPr>
 </p:pic>
 "
-  sprintf(str, label, ph, blipfill, xfrm_str, bg_str )
+  sprintf(str, label, alt_text, ph, blipfill, xfrm_str, bg_str )
 
 }
 

--- a/R/ppt_ph_with_methods.R
+++ b/R/ppt_ph_with_methods.R
@@ -320,7 +320,7 @@ ph_with.data.frame <- function(x, value, location, header = TRUE,
 #' @describeIn ph_with add a ggplot object to a new shape on the
 #' current slide. Use package \code{rvg} for more advanced graphical features.
 #' @param res resolution of the png image in ppi
-ph_with.gg <- function(x, value, location, res = 300, ...){
+ph_with.gg <- function(x, value, location, res = 300, alt_text, ...){
   location_ <- fortify_location(location, doc = x)
   slide <- x$slide$get_slide(x$cursor)
   if( !requireNamespace("ggplot2") )
@@ -339,7 +339,7 @@ ph_with.gg <- function(x, value, location, res = 300, ...){
   on.exit(unlink(file))
 
   ext_img <- external_img(file, width = width, height = height)
-  ph_with(x, ext_img, location = location )
+  ph_with(x, ext_img, location = location, alt_text = alt_text )
 }
 
 #' @export
@@ -389,7 +389,7 @@ ph_with.plot_instr <- function(x, value, location, res = 300, ...){
 #' specified in call to \code{external_img} will be
 #' ignored, their values will be those of the location,
 #' unless use_loc_size is set to FALSE.
-ph_with.external_img <- function(x, value, location, use_loc_size = TRUE, ...){
+ph_with.external_img <- function(x, value, location, use_loc_size = TRUE, alt_text, ...){
   location <- fortify_location(location, doc = x)
 
   slide <- x$slide$get_slide(x$cursor)
@@ -413,14 +413,13 @@ ph_with.external_img <- function(x, value, location, use_loc_size = TRUE, ...){
     value[1] <- file
     file_type <- ".png"
   }
-
   new_src <- tempfile( fileext = gsub("(.*)(\\.[a-zA-Z0-0]+)$", "\\2", as.character(value)) )
   file.copy( as.character(value), to = new_src )
 
   xml_str <- pic_pml(left = location$left, top = location$top,
                        width = width, height = height,
                        label = location$ph_label, ph = location$ph,
-                       rot = location$rotation, bg = location$bg, src = new_src)
+                       rot = location$rotation, bg = location$bg, src = new_src, alt_text = alt_text)
 
   slide$reference_img(src = new_src, dir_name = file.path(x$package_dir, "ppt/media"))
   xml_elt <- fortify_pml_images(x, xml_str)

--- a/R/ppt_ph_with_methods.R
+++ b/R/ppt_ph_with_methods.R
@@ -320,6 +320,7 @@ ph_with.data.frame <- function(x, value, location, header = TRUE,
 #' @describeIn ph_with add a ggplot object to a new shape on the
 #' current slide. Use package \code{rvg} for more advanced graphical features.
 #' @param res resolution of the png image in ppi
+#' @param alt_text Alt-text for screen-readers
 ph_with.gg <- function(x, value, location, res = 300, alt_text, ...){
   location_ <- fortify_location(location, doc = x)
   slide <- x$slide$get_slide(x$cursor)
@@ -381,6 +382,7 @@ ph_with.plot_instr <- function(x, value, location, res = 300, ...){
 #' @export
 #' @param use_loc_size if set to FALSE, external_img width and height will
 #' be used.
+#' @param alt_text Alt-text for screen-readers
 #' @describeIn ph_with add a \code{\link{external_img}} to a new shape
 #' on the current slide.
 #'

--- a/man/ph_with.Rd
+++ b/man/ph_with.Rd
@@ -41,11 +41,11 @@ ph_with(x, value, location, ...)
   ...
 )
 
-\method{ph_with}{gg}(x, value, location, res = 300, ...)
+\method{ph_with}{gg}(x, value, location, res = 300, alt_text, ...)
 
 \method{ph_with}{plot_instr}(x, value, location, res = 300, ...)
 
-\method{ph_with}{external_img}(x, value, location, use_loc_size = TRUE, ...)
+\method{ph_with}{external_img}(x, value, location, use_loc_size = TRUE, alt_text, ...)
 
 \method{ph_with}{fpar}(x, value, location, ...)
 
@@ -85,6 +85,8 @@ item 1 level will be 1, item 2 level will be 2.}
 and 'c' for center. Default to NULL.}
 
 \item{res}{resolution of the png image in ppi}
+
+\item{alt_text}{Alt-text for screen-readers}
 
 \item{use_loc_size}{if set to FALSE, external_img width and height will
 be used.}


### PR DESCRIPTION
Alt-text is an important way of making documents and presentation accessible to people who use screen readers. Alt-text should describe what the non-text content conveys. See https://www.w3.org/TR/WCAG21/#dfn-text-alternative 

Powerpoint slides provide this via the descr attribute. The changes in the pull request provide alt_text as an option for images added using officer that is stored in the descr attribute. 
