### PR TITLE
Enable table alignment from body_add_table()

### DIFF
--- a/R/docx_add.R
+++ b/R/docx_add.R
@@ -323,8 +323,8 @@ body_add_table <- function( x, value, style = NULL, pos = "after", header = TRUE
     tcf = table_conditional_formatting(
       first_row = first_row, first_column = first_column,
       last_row = last_row, last_column = last_column,
-      no_hband = no_hband, no_vband = no_vband)
-      align_table = align)
+      no_hband = no_hband, no_vband = no_vband),
+      align = align_table)
 
   bt <- block_table(x = value, header = header, properties = pt, alignment = alignment)
   xml_elt <- to_wml(bt, add_ns = TRUE, base_document = x)

--- a/R/docx_add.R
+++ b/R/docx_add.R
@@ -289,6 +289,7 @@ body_add_fpar <- function( x, value, style = NULL, pos = "after" ){
 #' @param header display header if TRUE
 #' @param alignment columns alignement, argument length must match with columns length,
 #' values must be "l" (left), "r" (right) or "c" (center).
+#' @param align_table table alignment within document, value must be "left", "center" or "right"
 #' @param stylenames columns styles defined by [table_stylenames()]
 #' @param first_row Specifies that the first column conditional formatting should be
 #' applied. Details for this and other conditional formatting options can be found
@@ -310,6 +311,7 @@ body_add_fpar <- function( x, value, style = NULL, pos = "after" ){
 #' @family functions for adding content
 body_add_table <- function( x, value, style = NULL, pos = "after", header = TRUE,
                             alignment = NULL,
+                            align_table = "center",
                             stylenames = table_stylenames(),
                             first_row = TRUE, first_column = FALSE,
                             last_row = FALSE, last_column = FALSE,
@@ -321,7 +323,8 @@ body_add_table <- function( x, value, style = NULL, pos = "after", header = TRUE
     tcf = table_conditional_formatting(
       first_row = first_row, first_column = first_column,
       last_row = last_row, last_column = last_column,
-      no_hband = no_hband, no_vband = no_vband))
+      no_hband = no_hband, no_vband = no_vband)
+      align_table = align)
 
   bt <- block_table(x = value, header = header, properties = pt, alignment = alignment)
   xml_elt <- to_wml(bt, add_ns = TRUE, base_document = x)

--- a/man/body_add_table.Rd
+++ b/man/body_add_table.Rd
@@ -11,6 +11,7 @@ body_add_table(
   pos = "after",
   header = TRUE,
   alignment = NULL,
+  align_table = "center",
   stylenames = table_stylenames(),
   first_row = TRUE,
   first_column = FALSE,
@@ -34,6 +35,8 @@ one of after", "before", "on".}
 
 \item{alignment}{columns alignement, argument length must match with columns length,
 values must be "l" (left), "r" (right) or "c" (center).}
+
+\item{align_table}{table alignment within document, value must be "left", "center" or "right"}
 
 \item{stylenames}{columns styles defined by \code{\link[=table_stylenames]{table_stylenames()}}}
 


### PR DESCRIPTION
Simple PR: fixes issue with `prop_table()` argument `align` not being accessible through `body_add_table`. Adds an `align_table` argument to pass values through to `align`. Named arg "align_table" to avoid confusion with the column alignment arg called "alignment."