### PR TITLE
Adding a scaling factor to ph_with.gg

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ Function `fp_text()` has also been adapted, it now supports NA meaning
 to not write the attributes as in `fp_text_lite()`.
 * new function `run_footnote` to add footnotes in a Word document (it 
 also makes possible to deprecate totally slip_in* functions).
+* new parameter `scale` added to `ph_with.gg`, `body_add_gg` and `body_add.gg` 
+to set the scale of ggplot outputs (like in ggsave).
 
 ## Issues
 

--- a/R/docx_add.R
+++ b/R/docx_add.R
@@ -118,6 +118,7 @@ body_add_docx <- function( x, src, pos = "after" ){
 #' @param width height in inches
 #' @param height height in inches
 #' @param res resolution of the png image in ppi
+#' @param scale Multiplicative scaling factor, same as in ggsave
 #' @param ... Arguments to be passed to png function.
 #' @importFrom grDevices png dev.off
 #' @examples
@@ -133,14 +134,14 @@ body_add_docx <- function( x, src, pos = "after" ){
 #'   print(doc, target = tempfile(fileext = ".docx") )
 #' }
 #' @family functions for adding content
-body_add_gg <- function( x, value, width = 6, height = 5, res = 300, style = "Normal", ... ){
+body_add_gg <- function( x, value, width = 6, height = 5, res = 300, style = "Normal", scale = 1, ... ){
 
   if( !requireNamespace("ggplot2") )
     stop("package ggplot2 is required to use this function")
 
   stopifnot(inherits(value, "gg") )
   file <- tempfile(fileext = ".png")
-  png(filename = file, width = width, height = height, units = "in", res = res, ...)
+  png(filename = file, width = width*scale, height = height*scale, units = "in", res = res, ...)
   print(value)
   dev.off()
   on.exit(unlink(file))
@@ -770,13 +771,14 @@ body_add.run_columnbreak <- function( x, value, style = NULL, ... ){
 #' @param width height in inches
 #' @param height height in inches
 #' @param res resolution of the png image in ppi
-body_add.gg <- function( x, value, width = 6, height = 5, res = 300, style = "Normal", ... ){
+#' @param scale Multiplicative scaling factor, same as in ggsave
+body_add.gg <- function( x, value, width = 6, height = 5, res = 300, style = "Normal", scale = 1, ... ){
 
   if( !requireNamespace("ggplot2") )
     stop("package ggplot2 is required to use this function")
 
   file <- tempfile(fileext = ".png")
-  png(filename = file, width = width, height = height, units = "in", res = res, ...)
+  png(filename = file, width = width*scale, height = height*scale, units = "in", res = res, ...)
   print(value)
   dev.off()
   on.exit(unlink(file))

--- a/R/ppt_ph_with_methods.R
+++ b/R/ppt_ph_with_methods.R
@@ -338,7 +338,8 @@ ph_with.data.frame <- function(x, value, location, header = TRUE,
 #' current slide. Use package \code{rvg} for more advanced graphical features.
 #' @param res resolution of the png image in ppi
 #' @param alt_text Alt-text for screen-readers
-ph_with.gg <- function(x, value, location, res = 300, alt_text, ...){
+#' @param scale Multiplicative scaling factor, same as in ggsave
+ph_with.gg <- function(x, value, location, res = 300, alt_text, scale = 1, ...){
   location_ <- fortify_location(location, doc = x)
   slide <- x$slide$get_slide(x$cursor)
   if( !requireNamespace("ggplot2") )
@@ -350,7 +351,7 @@ ph_with.gg <- function(x, value, location, res = 300, alt_text, ...){
 
   stopifnot(inherits(value, "gg") )
   file <- tempfile(fileext = ".png")
-  png(filename = file, width = width, height = height, units = "in", res = res, ...)
+  png(filename = file, width = width*scale, height = height*scale, units = "in", res = res, ...)
   print(value)
   dev.off()
   on.exit(unlink(file))

--- a/man/body_add.Rd
+++ b/man/body_add.Rd
@@ -51,7 +51,16 @@ body_add(x, value, ...)
 
 \method{body_add}{run_columnbreak}(x, value, style = NULL, ...)
 
-\method{body_add}{gg}(x, value, width = 6, height = 5, res = 300, style = "Normal", ...)
+\method{body_add}{gg}(
+  x,
+  value,
+  width = 6,
+  height = 5,
+  res = 300,
+  style = "Normal",
+  scale = 1,
+  ...
+)
 
 \method{body_add}{plot_instr}(x, value, width = 6, height = 5, res = 300, style = "Normal", ...)
 
@@ -89,6 +98,8 @@ values must be "l" (left), "r" (right) or "c" (center).}
 \item{height}{height in inches}
 
 \item{res}{resolution of the png image in ppi}
+
+\item{scale}{Multiplicative scaling factor, same as in ggsave}
 }
 \description{
 This function add objects into a Word document. Values are added

--- a/man/body_add_gg.Rd
+++ b/man/body_add_gg.Rd
@@ -4,7 +4,16 @@
 \alias{body_add_gg}
 \title{add ggplot}
 \usage{
-body_add_gg(x, value, width = 6, height = 5, res = 300, style = "Normal", ...)
+body_add_gg(
+  x,
+  value,
+  width = 6,
+  height = 5,
+  res = 300,
+  style = "Normal",
+  scale = 1,
+  ...
+)
 }
 \arguments{
 \item{x}{an rdocx object}
@@ -18,6 +27,8 @@ body_add_gg(x, value, width = 6, height = 5, res = 300, style = "Normal", ...)
 \item{res}{resolution of the png image in ppi}
 
 \item{style}{paragraph style}
+
+\item{scale}{Multiplicative scaling factor, same as in ggsave}
 
 \item{...}{Arguments to be passed to png function.}
 }

--- a/man/ph_with.Rd
+++ b/man/ph_with.Rd
@@ -41,7 +41,7 @@ ph_with(x, value, location, ...)
   ...
 )
 
-\method{ph_with}{gg}(x, value, location, res = 300, alt_text, ...)
+\method{ph_with}{gg}(x, value, location, res = 300, alt_text, scale = 1, ...)
 
 \method{ph_with}{plot_instr}(x, value, location, res = 300, ...)
 
@@ -87,6 +87,8 @@ and 'c' for center. Default to NULL.}
 \item{res}{resolution of the png image in ppi}
 
 \item{alt_text}{Alt-text for screen-readers}
+
+\item{scale}{Multiplicative scaling factor, same as in ggsave}
 
 \item{use_loc_size}{if set to FALSE, external_img width and height will
 be used.}


### PR DESCRIPTION
Adding a scaling factor to the plot, similar to the `scale` argument offered by `ggsave` in {ggplot2}.

Example below: 
* left scale = 1 (default)
* right scale = 2

<img width="773" alt="image" src="https://user-images.githubusercontent.com/33321678/138355412-d497c59a-0803-4956-b741-45442876a99c.png">
