### PR TITLE
Fix bug in ph_with methods introduced by PR #409.

### DIFF
--- a/R/ppt_ph_with_methods.R
+++ b/R/ppt_ph_with_methods.R
@@ -144,9 +144,9 @@ ph_with.character <- function(x, value, location, ...){
                ln = location$ln, geom = location$geom)
 
   pars <- paste0("<a:p><a:r><a:rPr/><a:t>", htmlEscapeCopy(value), "</a:t></a:r></a:p>", collapse = "")
-  xml_elt <- sprintf(paste0( psp_ns_yes, new_ph,
+  xml_elt <- paste0( psp_ns_yes, new_ph,
                      "<p:txBody><a:bodyPr/><a:lstStyle/>",
-                     pars, "</p:txBody></p:sp>" ))
+                     pars, "</p:txBody></p:sp>" )
 
   node <- as_xml_document(xml_elt)
 
@@ -265,9 +265,9 @@ ph_with.block_list <- function(x, value, location, level_list = integer(0), ...)
                rot = location$rotation, bg = location$bg,
                ln = location$ln, geom = location$geom)
 
-  xml_elt <- sprintf(paste0( psp_ns_yes, new_ph,
-                             "<p:txBody><a:bodyPr/><a:lstStyle/>",
-                             pars, "</p:txBody></p:sp>" ))
+  xml_elt <- paste0( psp_ns_yes, new_ph,
+                     "<p:txBody><a:bodyPr/><a:lstStyle/>",
+                     pars, "</p:txBody></p:sp>" )
 
   node <- as_xml_document(xml_elt)
 


### PR DESCRIPTION
Hi David,

this PR fixes a bug which I silently introduced with PR #409 . 

For whatever reason I accidentally wrapped `paste0`s in `ph_with.block_list` and `ph_with.character` in `sprintf` which in the devel version results in an error if character strings contain a `%` symbol.

A minimal reprex of the issue:

``` r
library(officer)

doc <- read_pptx()
doc <- add_slide(doc)
doc <- ph_with(doc, c("blah blah blah%"), location = ph_location_type(type = "body"))
#> Error in sprintf(paste0(psp_ns_yes, new_ph, "<p:txBody><a:bodyPr/><a:lstStyle/>", : too few arguments
```

``` r
value <- block_list(fpar(ftext("blah blah blah%")))
doc <- ph_with(doc, value, location = ph_location_type(type = "body"))
#> Error in sprintf(paste0(psp_ns_yes, new_ph, "<p:txBody><a:bodyPr/><a:lstStyle/>", : too few arguments
```

Sorry for the inconveniences.

Stefan