### PR TITLE
Add support for `ln` for `external_img`

### DIFF
--- a/R/ooxml_run_objects.R
+++ b/R/ooxml_run_objects.R
@@ -772,12 +772,15 @@ as.data.frame.external_img <- function( x, ... ){
 
 
 pic_pml <- function( left = 0, top = 0, width = 3, height = 3,
-                     bg = "transparent", rot = 0, label = "", ph = "<p:ph/>", src, alt_text = ""){
+                     bg = "transparent", rot = 0, label = "",
+                     ph = "<p:ph/>", src, alt_text = "",
+                     ln = sp_line(lwd = 0, linecmpd = "solid", lineend = "rnd")){
 
   if( !is.null(bg) && !is.color( bg ) )
     stop("bg must be a valid color.", call. = FALSE )
 
   bg_str <- solid_fill_pml(bg)
+  ln_str <- ln_pml(ln)
 
   if (missing(alt_text) || is.null(alt_text)) alt_text <- ""
 
@@ -799,10 +802,10 @@ pic_pml <- function( left = 0, top = 0, width = 3, height = 3,
     <p:nvPr>%s</p:nvPr>
   </p:nvPicPr>
   %s
-  <p:spPr>%s<a:prstGeom prst=\"rect\"><a:avLst/></a:prstGeom>%s</p:spPr>
+  <p:spPr>%s<a:prstGeom prst=\"rect\"><a:avLst/></a:prstGeom>%s%s</p:spPr>
 </p:pic>
 "
-  sprintf(str, label, alt_text, ph, blipfill, xfrm_str, bg_str )
+  sprintf(str, label, alt_text, ph, blipfill, xfrm_str, bg_str, ln_str)
 
 }
 

--- a/R/ppt_ph_with_methods.R
+++ b/R/ppt_ph_with_methods.R
@@ -445,7 +445,9 @@ ph_with.external_img <- function(x, value, location, use_loc_size = TRUE, ...){
   xml_str <- pic_pml(left = location$left, top = location$top,
                        width = width, height = height,
                        label = location$ph_label, ph = location$ph,
-                       rot = location$rotation, bg = location$bg, src = new_src, alt_text = attr(value, "alt"))
+                       rot = location$rotation, bg = location$bg,
+                       src = new_src, alt_text = attr(value, "alt"),
+                       ln = location$ln)
 
   slide$reference_img(src = new_src, dir_name = file.path(x$package_dir, "ppt/media"))
   xml_elt <- fortify_pml_images(x, xml_str)


### PR DESCRIPTION
Currently (eg v0.4.3) the `ln` argument to `ph_location` does not do anything for `ph_with` when value is an `external_img`. Eg: the following will _not_ put a red border around the image, despite the `sp_line` specification.

```
library(officer)                                                                                                                              

img.file <- file.path( R.home("doc"), "html", "logo.jpg" ) 
ppt <- read_pptx() 
ppt <- add_slide(ppt, layout = "Title and Content", master = "Office Theme")                                                                  

ppt <- ph_with(ppt, value = external_img(img.file, width = 2.78, height = 2.12), location = ph_location(left = 1, top = 2, ln = sp_line("red", lwd = 2)), use_loc_size = FALSE)                                                                                                          

print(ppt, "foo.pptx")
```

This PR adds support for `ln` to `pic_pml` so that images now get borders.

I am not particularly (or, at all) familiar with the guts of office documents, so this may be incorrectly implemented. I just copied the way it was done for `sh_props_pml` and it seems to work as I'd expect.