### PR TITLE
Prevents RStudio crash when document is open (Fix 360, 452)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# officer 0.6.3
+
+## Issues
+
+- Internal function `is_doc_open()` replaces `is_office_doc_edited()` to check if a document is open on Windows. This solves the issue where RStudio crashed while trying to write to an open Office document.
+
+
 # officer 0.6.2
 
 ## Issues

--- a/R/read_docx.R
+++ b/R/read_docx.R
@@ -149,11 +149,8 @@ print.rdocx <- function(x, target = NULL, ...) {
     stop(target, " should have '.docx' extension.")
   }
 
-  if (is_windows() && is_office_doc_edited(target)) {
-    stop(
-      target, " is already edited.",
-      " You must close the document in order to be able to write the file."
-    )
+  if (is_windows() && is_doc_open(target)) {
+    stop(target, " is open. To write to this document, please, close it.")
   }
 
   x <- process_sections(x)

--- a/R/read_pptx.R
+++ b/R/read_pptx.R
@@ -106,9 +106,9 @@ print.rpptx <- function(x, target = NULL, ...){
   if( !grepl(x = target, pattern = "\\.(pptx)$", ignore.case = TRUE) )
     stop(target , " should have '.pptx' extension.")
 
-  if(is_windows() && is_office_doc_edited(target))
-    stop(target , " is already edited.",
-         " You must close the document in order to be able to write the file.")
+  if (is_windows() && is_doc_open(target)) {
+    stop(target, " is open. To write to this document, please, close it.")
+  }
   x <- pptx_fortify_slides(x)
   x$rel$write(file.path(x$package_dir, "_rels", ".rels"))
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -230,19 +230,10 @@ is_windows <- function() {
   "windows" %in% .Platform$OS.type
 }
 
-is_office_doc_edited <- function(file) {
-
-  file_name <- sub("(.*)\\.(pptx|docx)$", "\\1", basename(file))
-
-  if (nchar(file_name) < 7 || endsWith(file, ".pptx")) {
-    edit_name <- paste0("~$", basename(file))
-  } else if (nchar(file_name) < 8) {
-    edit_name <- paste0("~$", substring(basename(file), 2))
-  } else {
-    edit_name <- paste0("~$", substring(basename(file), 3))
-  }
-
-  file.exists(file.path(dirname(file), edit_name))
+is_doc_open <- function(file) {
+  # The function checks if the `file` is open (a.k.a. is being edited).
+  # This function is valid on Windows operating system only.
+  suppressWarnings(!file.rename(from = file, to = file))
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -233,7 +233,7 @@ is_windows <- function() {
 is_doc_open <- function(file) {
   # The function checks if the `file` is open (a.k.a. is being edited).
   # This function is valid on Windows operating system only.
-  suppressWarnings(!file.rename(from = file, to = file))
+  suppressWarnings(file.exists(file) && !file.rename(from = file, to = file))
 }
 
 


### PR DESCRIPTION
This PR fixes #452 and #360 (issue on Windows).


-  #452 and #360

1) internal function `is_office_doc_edited()` is replaced with `is_doc_open()` as the later name reveals the essence of the function more clearly. 
2) More concise but precise error messages are used in the output enabled by `is_doc_open()` == `TRUE`
3) NEWS.md is updated.