### PR TITLE
Skip test requiring internet connection when offline

### DIFF
--- a/tests/testthat/test-missing-tableStyles.R
+++ b/tests/testthat/test-missing-tableStyles.R
@@ -1,14 +1,16 @@
-destfile = tempfile(fileext = ".pptx")
-download.file("https://ndownloader.figshare.com/files/16252631",
-              destfile = destfile)
-
 test_that("missing tableStyles file in pptx from figshare", {
+  testthat::skip_if_offline()
   testthat::skip_on_os("windows")
+
+  destfile <- tempfile(fileext = ".pptx")
+  on.exit(file.remove(destfile), add = TRUE)
+
+  download.file(
+    "https://ndownloader.figshare.com/files/16252631",
+    destfile = destfile
+  )
+
   expect_warning({
     x <- read_pptx(destfile)
   })
-
 })
-
-file.remove(destfile)
-


### PR DESCRIPTION
This PR improves the test in `tests/testthat/test-missing-tableStyles.R` to make sure that:

1. The internet file download operation is skipped when there is no internet connection, by adding `testthat::skip_if_offline()`.
2. The temporary file is deleted even if the test fails or is skipped by moving file system operations inside the test and use `on.exit(..., add = TRUE)`.

This helps passing the checks in air gapped environments with no internet connection.