### PR TITLE
feat: add preserve parameter to `pptx_summary()` (#493)

### DIFF
--- a/man/pptx_summary.Rd
+++ b/man/pptx_summary.Rd
@@ -4,10 +4,16 @@
 \alias{pptx_summary}
 \title{PowerPoint content in a data.frame}
 \usage{
-pptx_summary(x)
+pptx_summary(x, preserve = FALSE)
 }
 \arguments{
 \item{x}{an rpptx object}
+
+\item{preserve}{If \code{FALSE} (default), text in table cells is collapsed into a
+single line. If \code{TRUE}, line breaks in table cells are preserved as a "\\n"
+character. This feature is adapted from \code{docxtractr::docx_extract_tbl()}
+published under a \href{https://github.com/hrbrmstr/docxtractr/blob/master/LICENSE}{MIT licensed} in
+the \code{{docxtractr}} package by Bob Rudis.}
 }
 \description{
 Read content of a PowerPoint document and

--- a/tests/testthat/test-doc-summary.R
+++ b/tests/testthat/test-doc-summary.R
@@ -5,6 +5,10 @@ test_that("docx summary", {
   doc_data <- docx_summary(doc)
   table_data <- subset(doc_data, content_type %in% "table cell" & is_header)
   expect_equal( table_data$text, c("Petals", "Internode", "Sepal", "Bract") )
+
+  doc_data_pr <- docx_summary(doc, preserve = TRUE)
+  expect_equal( doc_data_pr[28, ][["text"]], "Note\nNew line note" )
+
 })
 
 test_that("complex docx table", {
@@ -51,10 +55,7 @@ test_that("pptx summary", {
   expect_equal( slide2_data$text, c("coco", "line of text", "blah blah blah") )
 
   doc_data_pr <- pptx_summary(doc, preserve = TRUE)
-  slide1_data_pr <- subset(doc_data_pr, content_type %in% "table cell" & slide_id == 1 & row_id == 3 & cell_id == 3)
-
-  expect_equal( slide1_data_pr[["text"]],
-                c("blah\n \nblah\n \nblah") )
+  expect_equal( doc_data_pr[23, ][["text"]], "blah\n \nblah\n \nblah" )
 })
 
 

--- a/tests/testthat/test-doc-summary.R
+++ b/tests/testthat/test-doc-summary.R
@@ -49,6 +49,12 @@ test_that("pptx summary", {
 
   slide2_data <- subset(doc_data, content_type %in% "paragraph" & slide_id == 2)
   expect_equal( slide2_data$text, c("coco", "line of text", "blah blah blah") )
+
+  doc_data_pr <- pptx_summary(doc, preserve = TRUE)
+  slide1_data_pr <- subset(doc_data_pr, content_type %in% "table cell" & slide_id == 1 & row_id == 3 & cell_id == 3)
+
+  expect_equal( slide1_data_pr[["text"]],
+                c("blah\n \nblah\n \nblah") )
 })
 
 


### PR DESCRIPTION
As a follow-up to #500, I added the same functionality to `pptx_summary()`. Hope this is similarly welcome!