### PR TITLE
Fix. Add alt text to ggplot's added to a pptx with ph_with.gg. Closes #556.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# officer 0.6.5.9000
+
+## Issues
+
+- Fix. Add alt text to ggplot's added to a pptx with ph_with.gg. Closes ##556.
+
 # officer 0.6.5
 
 ## Features 

--- a/R/ppt_ph_with_methods.R
+++ b/R/ppt_ph_with_methods.R
@@ -385,9 +385,10 @@ ph_with.data.frame <- function(x, value, location, header = TRUE,
 #' @describeIn ph_with add a ggplot object to a new shape on the
 #' current slide. Use package \code{rvg} for more advanced graphical features.
 #' @param res resolution of the png image in ppi
-#' @param alt_text Alt-text for screen-readers
+#' @param alt_text Alt-text for screen-readers. Defaults to `""`. If `""` or `NULL`
+#'    an alt text added with `ggplot2::labs(alt = ...)` will be used if any.
 #' @param scale Multiplicative scaling factor, same as in ggsave
-ph_with.gg <- function(x, value, location, res = 300, alt_text, scale = 1, ...) {
+ph_with.gg <- function(x, value, location, res = 300, alt_text = "", scale = 1, ...) {
   location_ <- fortify_location(location, doc = x)
   slide <- x$slide$get_slide(x$cursor)
   if (!requireNamespace("ggplot2")) {
@@ -405,8 +406,14 @@ ph_with.gg <- function(x, value, location, res = 300, alt_text, scale = 1, ...) 
   dev.off()
   on.exit(unlink(file))
 
-  ext_img <- external_img(file, width = width, height = height)
-  ph_with(x, ext_img, location = location, alt_text = alt_text)
+  if (is.null(alt_text) || alt_text == "") {
+    alt_text <- ggplot2::get_alt_text(value)
+    if (is.null(alt_text)) alt_text <- ""
+  }
+
+  ext_img <- external_img(file, width = width, height = height, alt = alt_text)
+
+  ph_with(x, ext_img, location = location)
 }
 
 #' @export

--- a/man/ph_with.Rd
+++ b/man/ph_with.Rd
@@ -41,7 +41,7 @@ ph_with(x, value, location, ...)
   ...
 )
 
-\method{ph_with}{gg}(x, value, location, res = 300, alt_text, scale = 1, ...)
+\method{ph_with}{gg}(x, value, location, res = 300, alt_text = "", scale = 1, ...)
 
 \method{ph_with}{plot_instr}(x, value, location, res = 300, ...)
 
@@ -86,7 +86,8 @@ and 'c' for center. Default to NULL.}
 
 \item{res}{resolution of the png image in ppi}
 
-\item{alt_text}{Alt-text for screen-readers}
+\item{alt_text}{Alt-text for screen-readers. Defaults to \code{""}. If \code{""} or \code{NULL}
+an alt text added with \code{ggplot2::labs(alt = ...)} will be used if any.}
 
 \item{scale}{Multiplicative scaling factor, same as in ggsave}
 

--- a/tests/testthat/test-alt-text.R
+++ b/tests/testthat/test-alt-text.R
@@ -1,0 +1,46 @@
+test_that("add alt text to ggplot", {
+  skip_if_not_installed("ggplot2")
+  require(ggplot2)
+
+  alt_text <- "Alt text added with 'alt_text='."
+
+  gg <- ggplot(mtcars, aes(factor(cyl))) +
+    geom_bar()
+
+  doc <- read_pptx()
+  doc <- add_slide(doc)
+  doc <- ph_with(doc,
+    value = gg,
+    location = ph_location_type("body"),
+    alt_text = alt_text
+  )
+
+  xmldoc <- doc$slide$get_slide(id = 1)$get()
+  expect_equal(
+    xml_attr(xml_find_all(xmldoc, "//p:nvPicPr//p:cNvPr"), "descr"),
+    alt_text
+  )
+
+  alt_labs <- "Alt text added with 'ggplot2::labs(alt=)'."
+  doc <- add_slide(doc)
+  doc <- ph_with(doc,
+    value = gg  + labs(alt = alt_labs),
+    location = ph_location_type("body")
+  )
+  xmldoc <- doc$slide$get_slide(id = 2)$get()
+  expect_equal(
+    xml_attr(xml_find_all(xmldoc, "//p:nvPicPr//p:cNvPr"), "descr"),
+    alt_labs
+  )
+
+  doc <- add_slide(doc)
+  doc <- ph_with(doc,
+                 value = gg,
+                 location = ph_location_type("body")
+  )
+  xmldoc <- doc$slide$get_slide(id = 3)$get()
+  expect_equal(
+    xml_attr(xml_find_all(xmldoc, "//p:nvPicPr//p:cNvPr"), "descr"),
+    ""
+  )
+})


### PR DESCRIPTION
This PR fixes a bug in ph_with.gg. It allows to add an alternative text to a ggplot with ph_with.gg again, thereby closing #556.

As a new feature an alt text added via `ggplot2::labs` is used as alt text by default if any.