### PR TITLE
docx_summary(): new parameter 'remove_field' (default FALSE) to remov…

### DIFF
--- a/R/fortify_docx.R
+++ b/R/fortify_docx.R
@@ -88,6 +88,7 @@ docxtable_as_tibble <- function( node, styles, preserve = FALSE ){
 
 par_as_tibble <- function(node, styles){
 
+
   style_node <- xml_child(node, "w:pPr/w:pStyle")
   if( inherits(style_node, "xml_missing") ){
     style_name <- NA
@@ -137,9 +138,17 @@ node_content <- function(node, x, preserve = FALSE){
 #'
 #' docx_summary(doc, preserve = TRUE)[28, ]
 #' @export
-docx_summary <- function( x, preserve = FALSE ){
-
+docx_summary <- function( x, preserve = FALSE, remove_fields = FALSE){
+  
+  
+  if(remove_fields){
+    instrText_nodes <- xml_find_all(x$doc_obj$get(),"//w:instrText")
+    xml_remove(instrText_nodes)
+  }  
+  
   all_nodes <- xml_find_all(x$doc_obj$get(),"/w:document/w:body/*[self::w:p or self::w:tbl]")
+  
+
   data <- lapply( all_nodes, node_content, x = x, preserve = preserve )
 
   data <- mapply(function(x, id) {


### PR DESCRIPTION

When working with word documents with field codes, officer currently reads the original field code, resulting in cumbersome unwanted text that is difficult to filter out automatically. 

This merge suggest to add a new parameter `remove_fields` to the doc_summary() function to prevent these field codes from appearing in the returned data.frame. The default value is `FALSE` to not break existing code.  

There seems to be two type of field codes, simple and complex. This concerns the complex variant 
(http://officeopenxml.com/WPfields.php ), by removing all `w:instrText` knodes. The results of the field codes should remain, as officer still will take read the content of the  `w:t` knodes (see example below, copied from link above):

```
<w:r>
<w:fldChar w:fldCharType="begin"/>
</w:r>
<w:r>
<w:instrText xml:space="preserve"> DATE </w:instrText>
</w:r>
<w:r>
<w:fldChar w:fldCharType="separate"/>
</w:r>
<w:r>
<w:t>12/31/2005</w:t>
</w:r>
<w:r>
<w:fldChar w:fldCharType="end"/>
</w:r>
```
Simple field codes do not need explicit handling, as they store their field code instruction in an xml attribute that does not get copied by officer (the result should be copied though). 

Note: Typo in commit message, should be 'remove_fields' (plural) instead of  'remove_field' for the parameter name