### PR TITLE
improve plot_layout_properties: correct slide width/height, add title (closes #577)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ replaced with a hyphen-minus (Unicode character 002D). Closes #573.
 
 ## Features
 
+- `plot_layout_properties()` gains a 'title' parameter, which will add the layout name as the plot title. Defaults to `FALSE`, to not alter the old behavior. Also, the slide width and height are now correctly displayed in the plot. Before, a box was drawn around the plot area. However, the plot area var with device size, not slide size.
 - `docx_summary()` gains parameter 'detailed' which allows to get a detailed 
 summary including formatting properties of runs in a paragraph. Formatting 
 properties are stored in a list column `run`, where each element 

--- a/R/pptx_informations.R
+++ b/R/pptx_informations.R
@@ -91,8 +91,9 @@ layout_properties <- function( x, layout = NULL, master = NULL ){
 #' @param x an rpptx object
 #' @param layout slide layout name to use
 #' @param master master layout name where \code{layout} is located
-#' @param labels if TRUE, placeholder labels will be printed, if FALSE
+#' @param labels if \code{TRUE}, placeholder labels will be printed, if \code{FALSE}
 #' placeholder types and identifiers will be printed.
+#' @param title if \code{FALSE}, a title with the layout name will be printed.
 #' @importFrom graphics plot rect text box
 #' @examples
 #' x <- read_pptx()
@@ -100,34 +101,41 @@ layout_properties <- function( x, layout = NULL, master = NULL ){
 #'   master = "Office Theme" )
 #' plot_layout_properties( x = x, layout = "Two Content" )
 #' @family functions for reading presentation informations
-plot_layout_properties <- function(x, layout = NULL, master = NULL, labels = TRUE){
+plot_layout_properties <- function (x, layout = NULL, master = NULL, labels = TRUE, title = FALSE)
+{
+  old_par <- par(mar = c(2, 2, 1.5, 0))
+  on.exit(par(old_par))
+
   dat <- layout_properties(x, layout = layout, master = master)
-  if(length(unique(dat$name)) != 1 ){
+  if (length(unique(dat$name)) != 1) {
     stop("one single layout need to be choosen")
   }
-
-  w <- slide_size(x)
-  h <- w$height
-  w <- w$width
-
+  s <- slide_size(x)
+  h <- s$height
+  w <- s$width
   offx <- dat$offx
   offy <- dat$offy
   cx <- dat$cx
   cy <- dat$cy
-  if(labels) labels <- dat$ph_label
+  if (labels)
+    labels <- dat$ph_label
   else {
     labels <- dat$type[order(as.integer(dat$id))]
     rle_ <- rle(labels)
-    labels <- sprintf("type: '%s' - id: %.0f", labels,
-           unlist(lapply(rle_$lengths, seq_len))
-    )
+    labels <- sprintf("type: '%s' - id: %.0f", labels, unlist(lapply(rle_$lengths,
+                                                                     seq_len)))
   }
-
-  plot(x = c(0, w), y = -c(0,h), asp = 1, type = "n", axes = FALSE, xlab = "x (inches)", ylab = "y (inches)")
-  rect(xleft = offx, xright = offx + cx, ybottom = -offy, ytop = -(offy + cy))
-  text(x = offx + cx/2, y= -(offy + cy/2), labels = labels, cex = .5, col = "red")
-  box()
+  plot(x = c(0, w), y = -c(0, h), asp = 1, type = "n", axes = FALSE, xlab = NA, ylab = NA)
+  if (title) {
+    title(main = paste("Layout:", layout))
+  }
+  rect(xleft = 0, xright = w, ybottom = 0, ytop = -h, border = "darkgrey")
+  rect(xleft = offx, xright = offx + cx, ybottom = -offy, ytop = -(offy +                                                                   cy))
+  text(x = offx + cx/2, y = -(offy + cy/2), labels = labels, cex = 0.5, col = "red")
+  mtext("y [inch]", side = 2, line = 0, cex = 1.2, col="darkgrey")
+  mtext("x [inch]", side = 1, line = 0, cex = 1.2, col="darkgrey")
 }
+
 
 #' @export
 #' @title Placeholder parameters annotation

--- a/man/plot_layout_properties.Rd
+++ b/man/plot_layout_properties.Rd
@@ -4,7 +4,13 @@
 \alias{plot_layout_properties}
 \title{Slide layout properties plot}
 \usage{
-plot_layout_properties(x, layout = NULL, master = NULL, labels = TRUE)
+plot_layout_properties(
+  x,
+  layout = NULL,
+  master = NULL,
+  labels = TRUE,
+  title = FALSE
+)
 }
 \arguments{
 \item{x}{an rpptx object}
@@ -13,8 +19,10 @@ plot_layout_properties(x, layout = NULL, master = NULL, labels = TRUE)
 
 \item{master}{master layout name where \code{layout} is located}
 
-\item{labels}{if TRUE, placeholder labels will be printed, if FALSE
+\item{labels}{if \code{TRUE}, placeholder labels will be printed, if \code{FALSE}
 placeholder types and identifiers will be printed.}
+
+\item{title}{if \code{FALSE}, a title with the layout name will be printed.}
 }
 \description{
 Plot slide layout properties and print informations


### PR DESCRIPTION
small visual improvement for `plot_layout_properties()`. 

Currently, a box is drawn around the plotted placeholders which does not reflect slide width and height properly, as it depends on device size. With the changes, a box with the proper slide height/width independent of device size is used. `plot_layout_properties()` also gains a 'title' parameter, which will add the layout name as the plot title. Defaults to `FALSE`, to not alter the old behavior. 

**Before**

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMzhydnJ6ZjUxNmx3YWthNXg5aW15ZmU4NHhsenBpcW9nY25waDA0dyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/n2koXg0MbKbcu4N6zk/giphy.gif)

**New**

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNXp5ZzNwYjg1bXIxZ2RjamJ3d3VnemhucnAyMjhzdWFsc2k1amNzdSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ZBpeU3CZLX8zso0Ae6/giphy.gif)