### PR TITLE
remove_fields in docx_summary(): also remove w:fldData nodes. 

### DIFF
--- a/R/fortify_docx.R
+++ b/R/fortify_docx.R
@@ -235,6 +235,7 @@ node_content <- function(node, x, preserve = FALSE, detailed = FALSE) {
 docx_summary <- function(x, preserve = FALSE, remove_fields = FALSE, detailed = FALSE) {
   if (remove_fields) {
     instrText_nodes <- xml_find_all(x$doc_obj$get(), "//w:instrText")
+    instrText_nodes <- xml_find_all(x$doc_obj$get(), "//w:fldData")
     xml_remove(instrText_nodes)
   }
 

--- a/R/fortify_docx.R
+++ b/R/fortify_docx.R
@@ -235,8 +235,10 @@ node_content <- function(node, x, preserve = FALSE, detailed = FALSE) {
 docx_summary <- function(x, preserve = FALSE, remove_fields = FALSE, detailed = FALSE) {
   if (remove_fields) {
     instrText_nodes <- xml_find_all(x$doc_obj$get(), "//w:instrText")
-    instrText_nodes <- xml_find_all(x$doc_obj$get(), "//w:fldData")
     xml_remove(instrText_nodes)
+    
+    fldData_nodes <- xml_find_all(x$doc_obj$get(), "//w:fldData")
+    xml_remove(fldData_nodes)
   }
 
   all_nodes <- xml_find_all(x$doc_obj$get(), "/w:document/w:body/*[self::w:p or self::w:tbl]")


### PR DESCRIPTION
Encountered a new xml node type today, that can be part of a complex fields `w:fldData`, for example EndNote seems to use it occasionally.  In this case it seemed to contain some type of binary data.

The contents of this node should not be displayed in the text of a .docx file (" No information or semantics are applied to the contents of this data by this Office Open XML Standard, and therefore this field may be used as desired to store additional application-specific data with the field", https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_Sections_topic_ID0ECA3S.html) . 

Thus, `remove_fields` should for consistency reasons also remove the content of `fldData` nodes from appearing in the summary data.

Attached one excerpt from the file where I encountered it, sorry for not sharing the whole file for copyright reasons. 
[xml_extract.txt](https://github.com/user-attachments/files/15744490/xml_extract.txt)

R package version should probably also be increased, but I leave that up to the maintainer(s) as I am unsure regarding the policy. 