### PR TITLE
fix: ph_location_type() - throw error for out of range type id (fix #602) and more info if ph type not present (close #601)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: officer
 Title: Manipulation of Microsoft Word and PowerPoint Documents
-Version: 0.6.7.009
+Version: 0.6.7.010
 Authors@R: c(
     person("David", "Gohel", , "david.gohel@ardata.fr", role = c("aut", "cre")),
     person("Stefan", "Moog", , "moogs@gmx.de", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,8 +15,8 @@ For example, `slideLayout2.xml` will now preceed `slideLayout10.xml`. Before, al
 - `layout_properties()` now returns all placeholders in case of multiple master (#597). Also, the internal `xfrmize()` 
 now sorts the resulting data by placeholder position. This yields an intuitive order, with placeholders sorted from 
 top to bottom and left to right.
-- `ph_location_type()` now throws an informative error if the `id` for a `type` is our of range or if 
-the type is not present in layout (#602).
+- `ph_location_type()` now throws an error if the `id` for a `type` is out of range (#602) and a more 
+informative error message if the type is not present in layout (#601).
 
 ## Features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,8 +15,8 @@ For example, `slideLayout2.xml` will now preceed `slideLayout10.xml`. Before, al
 - `layout_properties()` now returns all placeholders in case of multiple master (#597). Also, the internal `xfrmize()` 
 now sorts the resulting data by placeholder position. This yields an intuitive order, with placeholders sorted from 
 top to bottom and left to right.
-- `ph_location_type()` now throws an informative error if: `id` for a `type` is our of range or if 
-type exists but is not present in layout (#602).
+- `ph_location_type()` now throws an informative error if the `id` for a `type` is our of range or if 
+the type is not present in layout (#602).
 
 ## Features
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@ For example, `slideLayout2.xml` will now preceed `slideLayout10.xml`. Before, al
 - `layout_properties()` now returns all placeholders in case of multiple master (#597). Also, the internal `xfrmize()` 
 now sorts the resulting data by placeholder position. This yields an intuitive order, with placeholders sorted from 
 top to bottom and left to right.
+- `ph_location_type()` now throws an informative error if: `id` for a `type` is our of range or if 
+type exists but is not present in layout (#602).
 
 ## Features
 

--- a/R/ph_location.R
+++ b/R/ph_location.R
@@ -256,8 +256,6 @@ ph_location_type <- function(type = "body", position_right = TRUE, position_top 
       ),
       call = NULL
     )
-    # stop("argument type ('", type, "') expected to be a value of ",
-    #      paste0(shQuote(ph_types), collapse = ", "), ".")
   }
   x <- list(type = type, position_right = position_right, position_top = position_top, id = id, label = newlabel)
   class(x) <- c("location_type", "location_str")

--- a/R/ph_location.R
+++ b/R/ph_location.R
@@ -1,34 +1,49 @@
-get_ph_loc <- function(x, layout, master, type, position_right, position_top, id = NULL){
-
-  props <- layout_properties( x, layout = layout, master = master )
+get_ph_loc <- function(x, layout, master, type, position_right, position_top, id = NULL) {
+  props <- layout_properties(x, layout = layout, master = master)
+  types_on_layout <- unique(props$type)
   props <- props[props$type %in% type, , drop = FALSE]
-
-  if( nrow(props) < 1) {
-    stop("no selected row")
+  nr <- nrow(props)
+  if (nr < 1) {
+    cli::cli_abort(c(
+      "Found no placeholder of type {.val {type}} on layout {.val {layout}}.",
+      "x" = "Available types are {.val {types_on_layout}}",
+      "i" = cli::col_grey("see {.code layout_properties(x, '{layout}', '{master}')}")
+    ), call = NULL)
   }
-  if( !is.null(id) ){
-    props <- props[id,, drop = FALSE]
+
+  if (!is.null(id)) {
+    if (!id %in% 1L:nr) {
+      cli::cli_abort(
+        c(
+          "{.arg id} is out of range.",
+          "x" = "Must be between {.val {1L}} and {.val {nr}} for ph type {.val {type}}.",
+          "i" = cli::col_grey("see {.code layout_properties(x, '{layout}', '{master}')} for all phs with type '{type}'")
+        ),
+        call = NULL
+      )
+    }
+    props <- props[id, , drop = FALSE]
   } else {
-    if(position_right){
-      props <- props[props$offx + 0.0001 > max(props$offx),]
+    if (position_right) {
+      props <- props[props$offx + 0.0001 > max(props$offx), ]
     } else {
-      props <- props[props$offx - 0.0001 < min(props$offx),]
+      props <- props[props$offx - 0.0001 < min(props$offx), ]
     }
-    if(position_top){
-      props <- props[props$offy - 0.0001 < min(props$offy),]
+    if (position_top) {
+      props <- props[props$offy - 0.0001 < min(props$offy), ]
     } else {
-      props <- props[props$offy + 0.0001 > max(props$offy),]
+      props <- props[props$offy + 0.0001 > max(props$offy), ]
     }
   }
 
-
-  if( nrow(props) > 1) {
-    warning("more than a row have been selected")
+  if (nrow(props) > 1) {
+    cli::cli_alert_warning("More than one placeholder selected.")
   }
   props <- props[, c("offx", "offy", "cx", "cy", "ph_label", "ph", "type", "fld_id", "fld_type", "rotation")]
   names(props) <- c("left", "top", "width", "height", "ph_label", "ph", "type", "fld_id", "fld_type", "rotation")
   as_ph_location(props)
 }
+
 
 as_ph_location <- function(x, ...){
   if( !is.data.frame(x) ){
@@ -229,18 +244,27 @@ fortify_location.location_template <- function( x, doc, ...){
 #'
 #' fileout <- tempfile(fileext = ".pptx")
 #' print(doc, target = fileout)
-ph_location_type <- function( type = "body", position_right = TRUE, position_top = TRUE, newlabel = NULL, id = NULL, ...){
-
-  ph_types <- c("ctrTitle", "subTitle", "dt", "ftr", "sldNum", "title", "body",
-                "pic", "chart", "tbl", "dgm", "media", "clipArt")
-  if(!type %in% ph_types){
-    stop("argument type ('", type, "') expected to be a value of ",
-         paste0(shQuote(ph_types), collapse = ", "), ".")
+ph_location_type <- function(type = "body", position_right = TRUE, position_top = TRUE, newlabel = NULL, id = NULL, ...) {
+  ph_types <- c(
+    "ctrTitle", "subTitle", "dt", "ftr", "sldNum", "title", "body",
+    "pic", "chart", "tbl", "dgm", "media", "clipArt"
+  )
+  if (!type %in% ph_types) {
+    cli::cli_abort(
+      c("type {.val {type}} is unknown.",
+        "x" = "Must be one of {.or {.val {ph_types}}}"
+      ),
+      call = NULL
+    )
+    # stop("argument type ('", type, "') expected to be a value of ",
+    #      paste0(shQuote(ph_types), collapse = ", "), ".")
   }
   x <- list(type = type, position_right = position_right, position_top = position_top, id = id, label = newlabel)
   class(x) <- c("location_type", "location_str")
   x
 }
+
+
 #' @export
 fortify_location.location_type <- function( x, doc, ...){
 
@@ -250,7 +274,6 @@ fortify_location.location_type <- function( x, doc, ...){
 
   layout <- ifelse(is.null(args$layout), unique( xfrm$name ), args$layout)
   master <- ifelse(is.null(args$master), unique( xfrm$master_name ), args$master)
-
   out <- get_ph_loc(doc, layout = layout, master = master,
              type = x$type, position_right = x$position_right,
              position_top = x$position_top, id = x$id)

--- a/tests/testthat/test-pptx-add.R
+++ b/tests/testthat/test-pptx-add.R
@@ -1,7 +1,7 @@
 test_that("add wrong arguments", {
   doc <- read_pptx()
-  expect_error(add_slide(doc, "Title and blah", "Office Theme"))
-  expect_error(add_slide(doc, "Title and Content", "Office Tddheme"))
+  expect_error(add_slide(doc, "Title and blah", "Office Theme"), fixed = TRUE)
+  expect_error(add_slide(doc, "Title and Content", "Office Tddheme"), fixed = TRUE)
 })
 
 test_that("add simple elements into placeholder", {
@@ -271,6 +271,7 @@ test_that("empty_content in pptx", {
   expect_equal(slide_summary(doc)$cx, 2)
 })
 
+
 test_that("pptx ph locations", {
   doc <- read_pptx()
   doc <- add_slide(doc, "Title and Content", "Office Theme")
@@ -333,6 +334,32 @@ test_that("pptx ph locations", {
   observed_xfrm <- data.frame(offx = offx, offy = offy, cx = cx, cy = cy)
   expect_equivalent(observed_xfrm, theorical_xfrm)
 })
+
+
+test_that("pptx ph_location_type", {
+  opts <- options(cli.num_colors = 1) # suppress colors to check error message
+  on.exit(options(opts))
+
+  x <- read_pptx()
+  x <- x |> add_slide("Two Content")
+
+  expect_no_error({
+    x |> ph_with("correct ph type id", ph_location_type("body", id = 1))
+  })
+
+  expect_error({
+    x |> ph_with("out of range type id", ph_location_type("body", id = 3)) # 3 does not exists => no error or warning
+  }, regexp = "`id` is out of range.", fixed = TRUE)
+
+  expect_error({
+    x |> ph_with("type okay but not available in layout", ph_location_type("tbl")) # tbl not on layout
+  }, regexp = "Found no placeholder of type", fixed = TRUE)
+
+  expect_error({
+    x |> ph_with("xxx is unknown type", ph_location_type("xxx"))
+  }, regexp = 'type "xxx" is unknown', fixed = TRUE)
+})
+
 
 test_that("pptx ph labels", {
   doc <- read_pptx()


### PR DESCRIPTION
`ph_location_type()`:
1. now throws an error if the `id` for a `type` is out of range. Before, it went unnoticed (no error or warning) and caused a corrupted .pptx file (fix #602).
2.  generates a more informative error message when the type exists but is not present in the current layout (close #601).
3. error message if the type is unknown was rewritten using `cli` style message

----

**BEFORE**

```r 
library(officer)
x <- read_pptx()
x <- x |> add_slide("Two Content")

# 1) id=3 does not exists => no error or warning
x |> ph_with("unknown id", ph_location_type("body", id = 3)) 
pptx document with 1 slide(s)
Available layouts and their associated master(s) are:
             layout       master
1       Title Slide Office Theme
2 Title and Content Office Theme
3    Section Header Office Theme
4       Two Content Office Theme
5        Comparison Office Theme
6        Title Only Office Theme
7             Blank Office Theme

# 2) tbl is allowed type but not present in slide => error code not informative
x |> ph_with("unknown id", ph_location_type("tbl", id = 3))   
Error in get_ph_loc(doc, layout = layout, master = master, type = x$type,  : 
  no selected row

# 3) type is unkown
> x |> ph_with("unknown id", ph_location_type("xxx")) 
Error in ph_location_type("xxx") : 
  argument type ('xxx') expected to be a value of "ctrTitle", "subTitle", "dt", "ftr", "sldNum", "title", "body", "pic", "chart", "tbl", "dgm", "media", "clipArt".
```
----

**NEW**

```r
# 1) generates error now
x |> ph_with("unknown id", ph_location_type("body", id = 3))
Error:
! `id` is out of range.
✖ Must be between 1 and 2 for ph type "body".
ℹ see `layout_properties(x, 'Two Content', 'Office Theme')` for all phs with type 'body'

# 2) more informative error 
x |> ph_with("unknown id", ph_location_type("tbl", id = 3)) 
Error:
! Found no placeholder of type "tbl" on layout "Two Content".
✖ Available types are "body", "dt", "ftr", "sldNum", and "title"
ℹ see `layout_properties(x, 'Two Content', 'Office Theme')`

# 3) error message in cli style
x |> ph_with("unknown id", ph_location_type("xxx")) 
Error:
! type "xxx" is unknown.
✖ Must be one of "ctrTitle", "subTitle", "dt", "ftr", "sldNum", "title",
  "body", "pic", "chart", "tbl", "dgm", "media", or "clipArt"
```

