### PR TITLE
Add unit= argument to body_add_gg, ... . Closes #626

### DIFF
--- a/R/docx_add.R
+++ b/R/docx_add.R
@@ -24,7 +24,6 @@ body_add_break <- function(x, pos = "after") {
 #' Defaults to "in"ches.
 #' @param unit One of the following units in which the width and height
 #' arguments are expressed: "in", "cm" or "mm".
-#' @param ... Additional arguments passed on to methods. Not currently used.
 #' @examples
 #' doc <- read_docx()
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -334,6 +334,24 @@ stop_if_not_rpptx <- function(x, arg = NULL) {
   stop_if_not_class(x, "rpptx", arg)
 }
 
+check_unit <- function(unit, choices, several.ok = FALSE) {
+  if (!several.ok && length(unit) != 1) {
+    cli::cli_abort(
+      c("{.arg unit} is not length 1.",
+        "x" = "{.arg unit} must be {.emph a string}."
+      )
+    )
+  }
+  if (!unit %in% choices) {
+    cli::cli_abort(
+      c("{.arg unit} should be one of {.or {choices}}.",
+        "x" = "{.arg unit} was {.emph {unit}\"}."
+      )
+    )
+  }
+
+  unit
+}
 
 # htmlEscapeCopy ----
 

--- a/man/body_add.Rd
+++ b/man/body_add.Rd
@@ -56,13 +56,23 @@ body_add(x, value, ...)
   value,
   width = 6,
   height = 5,
+  unit = "in",
   res = 300,
   style = "Normal",
   scale = 1,
   ...
 )
 
-\method{body_add}{plot_instr}(x, value, width = 6, height = 5, res = 300, style = "Normal", ...)
+\method{body_add}{plot_instr}(
+  x,
+  value,
+  width = 6,
+  height = 5,
+  unit = "in",
+  res = 300,
+  style = "Normal",
+  ...
+)
 
 \method{body_add}{block_pour_docx}(x, value, ...)
 
@@ -93,9 +103,11 @@ argument \code{path} from \link{read_docx}).}
 \item{alignment}{columns alignement, argument length must match with columns length,
 values must be "l" (left), "r" (right) or "c" (center).}
 
-\item{width}{height in inches}
+\item{width, height}{plot size in units expressed by the unit argument.
+Defaults to a width of 6 and a height of 5 "in"ches.}
 
-\item{height}{height in inches}
+\item{unit}{One of the following units in which the width and height
+arguments are expressed: "in", "cm" or "mm".}
 
 \item{res}{resolution of the png image in ppi}
 

--- a/man/body_add_gg.Rd
+++ b/man/body_add_gg.Rd
@@ -9,6 +9,7 @@ body_add_gg(
   value,
   width = 6,
   height = 5,
+  unit = "in",
   res = 300,
   style = "Normal",
   scale = 1,
@@ -21,9 +22,11 @@ body_add_gg(
 
 \item{value}{ggplot object}
 
-\item{width}{height in inches}
+\item{width, height}{plot size in units expressed by the unit argument.
+Defaults to a width of 6 and a height of 5 "in"ches.}
 
-\item{height}{height in inches}
+\item{unit}{One of the following units in which the width and height
+arguments are expressed: "in", "cm" or "mm".}
 
 \item{res}{resolution of the png image in ppi}
 
@@ -48,6 +51,9 @@ if (require("ggplot2")) {
 
   if (capabilities(what = "png")) {
     doc <- body_add_gg(doc, value = gg_plot, style = "centered")
+
+    # Set the unit in which the width and height arguments are expressed
+    doc <- body_add_gg(doc, value = gg_plot, style = "centered", unit = "cm")
   }
 
   print(doc, target = tempfile(fileext = ".docx"))

--- a/man/body_add_img.Rd
+++ b/man/body_add_img.Rd
@@ -21,8 +21,6 @@ arguments are expressed: "in", "cm" or "mm".}
 
 \item{pos}{where to add the new element relative to the cursor,
 one of "after", "before", "on".}
-
-\item{...}{Additional arguments passed on to methods. Not currently used.}
 }
 \description{
 add an image into an rdocx object.

--- a/man/body_add_img.Rd
+++ b/man/body_add_img.Rd
@@ -4,7 +4,7 @@
 \alias{body_add_img}
 \title{Add an image in a 'Word' document}
 \usage{
-body_add_img(x, src, style = NULL, width, height, pos = "after")
+body_add_img(x, src, style = NULL, width, height, unit = "in", pos = "after")
 }
 \arguments{
 \item{x}{an rdocx object}
@@ -13,12 +13,16 @@ body_add_img(x, src, style = NULL, width, height, pos = "after")
 
 \item{style}{paragraph style}
 
-\item{width}{height in inches}
+\item{width, height}{image size in units expressed by the unit argument.
+Defaults to "in"ches.}
 
-\item{height}{height in inches}
+\item{unit}{One of the following units in which the width and height
+arguments are expressed: "in", "cm" or "mm".}
 
 \item{pos}{where to add the new element relative to the cursor,
 one of "after", "before", "on".}
+
+\item{...}{Additional arguments passed on to methods. Not currently used.}
 }
 \description{
 add an image into an rdocx object.
@@ -29,6 +33,13 @@ doc <- read_docx()
 img.file <- file.path(R.home("doc"), "html", "logo.jpg")
 if (file.exists(img.file)) {
   doc <- body_add_img(x = doc, src = img.file, height = 1.06, width = 1.39)
+
+  # Set the unit in which the width and height arguments are expressed
+  doc <- body_add_img(
+    x = doc, src = img.file,
+    height = 2.69, width = 3.53,
+    unit = "cm"
+  )
 }
 
 print(doc, target = tempfile(fileext = ".docx"))

--- a/man/body_add_plot.Rd
+++ b/man/body_add_plot.Rd
@@ -9,6 +9,7 @@ body_add_plot(
   value,
   width = 6,
   height = 5,
+  unit = "in",
   res = 300,
   style = "Normal",
   pos = "after",
@@ -20,9 +21,11 @@ body_add_plot(
 
 \item{value}{plot instructions, see \code{\link[=plot_instr]{plot_instr()}}.}
 
-\item{width}{height in inches}
+\item{width, height}{plot size in units expressed by the unit argument.
+Defaults to a width of 6 and a height of 5 "in"ches.}
 
-\item{height}{height in inches}
+\item{unit}{One of the following units in which the width and height
+arguments are expressed: "in", "cm" or "mm".}
 
 \item{res}{resolution of the png image in ppi}
 
@@ -40,14 +43,16 @@ Add a plot as a png image into an rdocx object.
 doc <- read_docx()
 
 if (capabilities(what = "png")) {
-  doc <- body_add_plot(doc,
-    value = plot_instr(
+  p <- plot_instr(
       code = {
         barplot(1:5, col = 2:6)
       }
-    ),
-    style = "centered"
-  )
+    )
+
+  doc <- body_add_plot(doc, value = p, style = "centered")
+
+  # Set the unit in which the width and height arguments are expressed
+  doc <- body_add_plot(doc, value = p, style = "centered", unit = "cm")
 }
 
 print(doc, target = tempfile(fileext = ".docx"))

--- a/man/body_replace_gg_at_bkm.Rd
+++ b/man/body_replace_gg_at_bkm.Rd
@@ -38,9 +38,8 @@ body_replace_plot_at_bkm(
 \item{value}{a ggplot object for body_replace_gg_at_bkm() or a set plot instructions
 body_replace_plot_at_bkm(), see plot_instr().}
 
-\item{width}{height in inches}
-
-\item{height}{height in inches}
+\item{width, height}{plot size in units expressed by the unit argument.
+Defaults to a width of 6 and a height of 5 "in"ches.}
 
 \item{res}{resolution of the png image in ppi}
 


### PR DESCRIPTION
Hi David,

this PR adds a "unit=" argument to body_add_gg, ... thereby closing #626.

The reprex below shows that it (should) work:

``` r
library(officer)
library(ggplot2)

p <- ggplot(data = mtcars, aes(x = wt, y = mpg)) +
  geom_point()

doc <- read_docx()

doc <- body_add_gg(doc, p) # Works when unit is not set -> #323
doc <- body_add_gg(doc, p, unit = "in")
doc <- body_add_gg(doc, p, unit = "cm")
doc <- body_add_gg(doc, p, unit = "mm")

# In all 4 cases a plot is added with a width of 6 and height of 5 in units
# expressed by the unit argument

doc <- cursor_end(doc)
node <- docx_current_block_xml(doc)

.in_to_emu <- 914400; .cm_to_emu <- 360000; .mm_to_emu <- 36000

all(identical(
  as.numeric(xml2::xml_attr(xml2::xml_find_all(node, "//wp:extent"), "cx")) /
    c(.in_to_emu, .in_to_emu, .cm_to_emu, .mm_to_emu),
  rep(6, 4)
))
#> [1] TRUE

all(identical(
  as.numeric(xml2::xml_attr(xml2::xml_find_all(node, "//wp:extent"), "cy")) /
    c(.in_to_emu, .in_to_emu, .cm_to_emu, .mm_to_emu),
  rep(5, 4)
))
#> [1] TRUE

# Uses cli_abort for nice error messages

doc <- body_add_gg(doc, p, unit = "px")
#> Error in `check_unit()`:
#> ! `unit` should be one of in, cm, or mm.
#> ✖ `unit` was px".
doc <- body_add_gg(doc, p, unit = c("cm", "mm"))
#> Error in `check_unit()`:
#> ! `unit` is not length 1.
#> ✖ `unit` must be a string.
doc <- body_add_gg(doc, p, units = "cm")
#> Error in `body_add_gg()`:
#> ! Found a `units` argument. Did you mean `unit`?
```