### PR TITLE
*For setting 'detailed=TRUE', 'par_as_tibble()' seems to call te 'run…

### DIFF
--- a/R/fortify_docx.R
+++ b/R/fortify_docx.R
@@ -131,7 +131,7 @@ par_as_tibble <- function(node, styles, detailed = FALSE) {
 
   if (detailed) {
     nodes_run <- xml_find_all(node, "w:r")
-    run_data <- lapply(nodes_run, run_as_tibble)
+    run_data <- lapply(nodes_run, run_as_tibble, styles = styles)
 
     run_data <- mapply(function(x, id) {
       x$id <- id
@@ -236,7 +236,7 @@ docx_summary <- function(x, preserve = FALSE, remove_fields = FALSE, detailed = 
   if (remove_fields) {
     instrText_nodes <- xml_find_all(x$doc_obj$get(), "//w:instrText")
     xml_remove(instrText_nodes)
-    
+
     fldData_nodes <- xml_find_all(x$doc_obj$get(), "//w:fldData")
     xml_remove(fldData_nodes)
   }


### PR DESCRIPTION
Attempted to get run information from 'doc_summary()' by setting 'detailed=T', but got a bug. 

par_as_tibble()'  seems to attempt 'run_as_tibble()' function without the mandatory 'styles' argument on line 134 in fortify_docx.R. Attempt to fix by forwarding the 'styles' argument as an additional 'lapply()' argument where 'run_as_tibble()' is applied to each element in 'nodes' run. 

This seems to fix the bug, a column with run information is added to the resulting dataframe from 'doc_summary()'. 
Checked one of these run dataframes , seemed to be correct, but I did not check extensively if the  run information is correct. 