### PR TITLE
Fix lists with `body_import_docx()` from officedown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,6 +61,7 @@ Suggests:
     ggplot2,
     knitr,
     magick,
+    officedown,
     rmarkdown,
     rsvg,
     testthat,

--- a/R/docx_part.R
+++ b/R/docx_part.R
@@ -158,11 +158,11 @@ numberings_append_xml <- function(file_numbering_from, file_numbering_to) {
 
   used_num_id_to <- xml_attr(num_to, "numId")
   used_num_id_to <- as.integer(used_num_id_to)
-  used_num_id_to_next <- max(used_num_id_to) + 1L
+  used_num_id_to_next <- if (length(used_num_id_to) > 0) max(used_num_id_to) + 1L else 1L
 
   abst_num_id_to <- xml_attr(abstractnum_to, "abstractNumId")
   abst_num_id_to <- as.integer(abst_num_id_to)
-  abst_num_id_to_next <- max(abst_num_id_to) + 1L
+  abst_num_id_to_next <- if (length(abst_num_id_to) > 0) max(abst_num_id_to) + 1L else 0L
 
   used_num_id_from <- xml_attr(num_from, "numId")
   used_num_id_from <- as.integer(used_num_id_from)
@@ -176,7 +176,7 @@ numberings_append_xml <- function(file_numbering_from, file_numbering_to) {
     abstractNumFrom <- xml_find_first(
       numbering_from,
       sprintf(
-        "w:abstractNum[contains(@w:abstractNumId, '%s')]",
+        "w:abstractNum[@w:abstractNumId='%s']",
         as.character(id_from)
       )
     )
@@ -187,7 +187,7 @@ numberings_append_xml <- function(file_numbering_from, file_numbering_to) {
     usedAbsNumFrom <- xml_find_all(
       numbering_from,
       sprintf(
-        "w:num/w:abstractNumId[contains(@w:val, '%s')]",
+        "w:num/w:abstractNumId[@w:val='%s']",
         as.character(id_from)
       )
     )
@@ -205,7 +205,7 @@ numberings_append_xml <- function(file_numbering_from, file_numbering_to) {
     id_to <- mapping_from$to[i]
     usedNumFrom <- xml_find_all(
       numbering_from,
-      sprintf("w:num[contains(@w:numId, '%s')]", as.character(id_from))
+      sprintf("w:num[@w:numId='%s']", as.character(id_from))
     )
     xml_attr(usedNumFrom, "w:numId") <- as.character(id_to)
   }

--- a/tests/testthat/test-numbering-empty-target.R
+++ b/tests/testthat/test-numbering-empty-target.R
@@ -1,0 +1,64 @@
+test_that("body_import_docx preserves list formatting from officedown documents", {
+  # This test verifies the fix for issue #694
+  # When importing from officedown-generated documents with high numIds (1000+),
+  # the function should properly add all numbering definitions
+
+  skip_if_not_installed("officedown")
+  skip_if_not_installed("rmarkdown")
+
+  # Create RMarkdown file with both ordered and bulleted lists
+  rmd_file <- tempfile(fileext = ".Rmd")
+  writeLines("---
+output: officedown::rdocx_document
+---
+
+# Lists Test
+
+Ordered list:
+
+1. Item 1
+2. Item 2
+
+Bulleted list:
+
+- Item A
+- Item B
+", rmd_file)
+
+  output_file <- tempfile(fileext = ".docx")
+  rmarkdown::render(rmd_file, quiet = TRUE, output_file = output_file)
+
+  target <- read_docx()
+  target <- body_add_par(target, "Frontmatter", style = "heading 1")
+
+  target <- body_import_docx(target, output_file, par_style_mapping = list(
+    "Normal" = c("First Paragraph", "Compact")
+  ))
+
+  target_file <- tempfile(fileext = ".docx")
+  print(target, target = target_file)
+
+  result <- read_docx(target_file)
+  result_summary <- docx_summary(result)
+  list_items <- result_summary[!is.na(result_summary$num_id), ]
+
+  expect_equal(nrow(list_items), 4)
+
+  # Verify numbering definitions exist and have correct formats
+  library(xml2)
+  result_numbering <- read_xml(file.path(result$package_dir, "word/numbering.xml"))
+
+  # Check that the numIds used in the document have corresponding definitions
+  for (num_id in unique(list_items$num_id)) {
+    num_node <- xml_find_first(result_numbering, sprintf("//w:num[@w:numId='%d']", num_id))
+    expect_false(is.na(num_node), info = sprintf("num %d should exist in numbering.xml", num_id))
+
+    # Verify it has a valid abstractNum reference
+    abstract_ref <- xml_find_first(num_node, ".//w:abstractNumId")
+    expect_false(is.na(abstract_ref))
+    abstract_id <- xml_attr(abstract_ref, "val")
+
+    abstract_node <- xml_find_first(result_numbering, sprintf("//w:abstractNum[@w:abstractNumId='%s']", abstract_id))
+    expect_false(is.na(abstract_node), info = sprintf("abstractNum %s should exist", abstract_id))
+  }
+})


### PR DESCRIPTION
This addresses issue: https://github.com/davidgohel/officer/issues/694

I kept the unit test in a separate commit in case you want a different style of test.

I can confirm this visually fixes the original bug. Screenshot from the reprex in [the issue](https://github.com/davidgohel/officer/issues/694):

<img width="138" height="151" alt="image" src="https://github.com/user-attachments/assets/d32fe033-a2b0-4660-b682-bec67a1f85ef" />
